### PR TITLE
Fix the service class name

### DIFF
--- a/zello-sdk/src/com/zello/sdk/Sdk.java
+++ b/zello-sdk/src/com/zello/sdk/Sdk.java
@@ -915,7 +915,7 @@ class Sdk implements SafeHandlerEvents, ServiceConnection {
 
 	private @NonNull Intent getServiceIntentNew() {
 		Intent intent = new Intent();
-		return intent.setClassName(_package, "com.zello.client.ui.Svc");
+		return intent.setClassName(_package, "com.zello.ui.Svc");
 	}
 
 	private @NonNull Intent getServiceIntentOld() {


### PR DESCRIPTION
This takes care of a warning message showing up in the ADB log when the SDK is used with recent versions of com.pttsdk and net.loudtalks apps. The SDK will work with older versions of the app still but will log the very same warning that's being taken care of in this PR.

Closes #39